### PR TITLE
polish(home): student-led copy, Brand Navy CTAs, motion guards

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,350 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-05-29T00:00:00.000Z",
+  "title": "Design System: CEUS Website",
+  "extensions": {
+    "colorMeta": {
+      "brand-navy": {
+        "role": "primary",
+        "displayName": "Brand Navy",
+        "canonical": "oklch(33.5% 0.108 263)",
+        "tonalRamp": [
+          "#0A1530",
+          "#0F2148",
+          "#142C61",
+          "#1B397E",
+          "#2A4C9C",
+          "#4368BC",
+          "#7A95D2",
+          "#C8D3EC"
+        ]
+      },
+      "accent-blue": {
+        "role": "secondary",
+        "displayName": "Accent Blue",
+        "canonical": "oklch(54.6% 0.215 262)",
+        "tonalRamp": [
+          "#172554",
+          "#1E3A8A",
+          "#1D4ED8",
+          "#2563EB",
+          "#3B82F6",
+          "#60A5FA",
+          "#93C5FD",
+          "#EFF6FF"
+        ]
+      },
+      "accent-blue-deep": {
+        "role": "secondary",
+        "displayName": "Accent Blue Deep",
+        "canonical": "oklch(48.8% 0.232 263)",
+        "tonalRamp": [
+          "#172554",
+          "#1E3A8A",
+          "#1D4ED8",
+          "#2563EB",
+          "#3B82F6",
+          "#60A5FA",
+          "#93C5FD",
+          "#DBEAFE"
+        ]
+      },
+      "surface-white": {
+        "role": "neutral",
+        "displayName": "Paper White",
+        "canonical": "oklch(100% 0 0)",
+        "tonalRamp": [
+          "#FFFFFF",
+          "#FAFAFA",
+          "#F5F5F5",
+          "#E5E7EB",
+          "#D1D5DB",
+          "#9CA3AF",
+          "#6B7280",
+          "#1F2937"
+        ]
+      },
+      "surface-tint-blue": {
+        "role": "neutral",
+        "displayName": "Tinted Blue Pill",
+        "canonical": "oklch(97% 0.013 248)",
+        "tonalRamp": [
+          "#DBEAFE",
+          "#E0E7FF",
+          "#EFF6FF",
+          "#F1F5FE",
+          "#F4F7FF",
+          "#F9FAFF",
+          "#FCFDFF",
+          "#FFFFFF"
+        ]
+      },
+      "ink-strong": {
+        "role": "neutral",
+        "displayName": "Ink Strong",
+        "canonical": "oklch(28.5% 0.025 264)",
+        "tonalRamp": [
+          "#0F172A",
+          "#1F2937",
+          "#374151",
+          "#4B5563",
+          "#6B7280",
+          "#9CA3AF",
+          "#D1D5DB",
+          "#F3F4F6"
+        ]
+      },
+      "ink-body": {
+        "role": "neutral",
+        "displayName": "Ink Body",
+        "canonical": "oklch(35.4% 0.024 265)",
+        "tonalRamp": [
+          "#1F2937",
+          "#374151",
+          "#4B5563",
+          "#6B7280",
+          "#9CA3AF",
+          "#D1D5DB",
+          "#E5E7EB",
+          "#F9FAFB"
+        ]
+      },
+      "ink-muted": {
+        "role": "neutral",
+        "displayName": "Ink Muted",
+        "canonical": "oklch(42% 0.022 265)",
+        "tonalRamp": [
+          "#1F2937",
+          "#374151",
+          "#4B5563",
+          "#6B7280",
+          "#9CA3AF",
+          "#D1D5DB",
+          "#E5E7EB",
+          "#F9FAFB"
+        ]
+      },
+      "ink-soft": {
+        "role": "neutral",
+        "displayName": "Ink Soft",
+        "canonical": "oklch(50% 0.018 265)",
+        "tonalRamp": [
+          "#374151",
+          "#4B5563",
+          "#6B7280",
+          "#9CA3AF",
+          "#D1D5DB",
+          "#E5E7EB",
+          "#F3F4F6",
+          "#F9FAFB"
+        ]
+      },
+      "hairline": {
+        "role": "neutral",
+        "displayName": "Hairline",
+        "canonical": "oklch(91% 0.005 265)",
+        "tonalRamp": [
+          "#6B7280",
+          "#9CA3AF",
+          "#D1D5DB",
+          "#E5E7EB",
+          "#EEEFF1",
+          "#F3F4F6",
+          "#F9FAFB",
+          "#FFFFFF"
+        ]
+      },
+      "category-flagship-bg": {
+        "role": "tertiary",
+        "displayName": "Flagship Plum",
+        "canonical": "oklch(94% 0.05 320)",
+        "tonalRamp": ["#581C87","#7E22CE","#A855F7","#C084FC","#D8B4FE","#E9D5FF","#F3E8FF","#FAF5FF"]
+      },
+      "category-careers-bg": {
+        "role": "tertiary",
+        "displayName": "Careers Blue",
+        "canonical": "oklch(93% 0.045 250)",
+        "tonalRamp": ["#1E3A8A","#1D4ED8","#2563EB","#3B82F6","#60A5FA","#93C5FD","#DBEAFE","#EFF6FF"]
+      },
+      "category-social-bg": {
+        "role": "tertiary",
+        "displayName": "Social Green",
+        "canonical": "oklch(94% 0.06 145)",
+        "tonalRamp": ["#14532D","#166534","#15803D","#16A34A","#22C55E","#86EFAC","#DCFCE7","#F0FDF4"]
+      },
+      "category-academic-bg": {
+        "role": "tertiary",
+        "displayName": "Academic Amber",
+        "canonical": "oklch(94% 0.06 75)",
+        "tonalRamp": ["#7C2D12","#9A3412","#C2410C","#EA580C","#F97316","#FB923C","#FFEDD5","#FFF7ED"]
+      },
+      "category-welfare-bg": {
+        "role": "tertiary",
+        "displayName": "Welfare Pink",
+        "canonical": "oklch(94% 0.045 0)",
+        "tonalRamp": ["#831843","#9D174D","#BE185D","#DB2777","#EC4899","#F472B6","#FCE7F3","#FDF2F8"]
+      },
+      "category-recruitment-bg": {
+        "role": "tertiary",
+        "displayName": "Recruitment Indigo",
+        "canonical": "oklch(94% 0.045 280)",
+        "tonalRamp": ["#312E81","#3730A3","#4338CA","#4F46E5","#6366F1","#818CF8","#E0E7FF","#EEF2FF"]
+      },
+      "category-collab-bg": {
+        "role": "tertiary",
+        "displayName": "Collaboration Teal",
+        "canonical": "oklch(94% 0.05 175)",
+        "tonalRamp": ["#134E4A","#115E59","#0F766E","#0D9488","#14B8A6","#5EEAD4","#CCFBF1","#F0FDFA"]
+      },
+      "category-other-bg": {
+        "role": "tertiary",
+        "displayName": "Neutral Other",
+        "canonical": "oklch(96% 0 0)",
+        "tonalRamp": ["#1F2937","#374151","#4B5563","#6B7280","#9CA3AF","#D1D5DB","#F3F4F6","#F9FAFB"]
+      }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Display — Tracked Hero", "purpose": "The homepage wordmark 'UNSW CEUS.' Tracked 0.1875em to give the brand bearing." },
+      "subdisplay": { "displayName": "Subdisplay — Hero Subtitle", "purpose": "The 'Chemical Engineering Undergraduate Society' line under the wordmark; light against the bold display." },
+      "headline": { "displayName": "Headline", "purpose": "Page-level h2 ('Interested in Sponsoring CEUS?', 'Meet the Team')." },
+      "title": { "displayName": "Title", "purpose": "Card titles — event names, member names, sponsor names." },
+      "body": { "displayName": "Body", "purpose": "Default paragraph copy. Capped at 65–75ch in long-form sections." },
+      "label": { "displayName": "Label", "purpose": "Category chips, metadata badges. Sentence case, not uppercase." }
+    },
+    "shadows": [
+      { "name": "header-rest", "value": "0 1px 2px 0 rgb(0 0 0 / 0.05)", "purpose": "Separates the white header from white page surfaces." },
+      { "name": "card-rest", "value": "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)", "purpose": "Default elevation for event and member cards." },
+      { "name": "card-hover", "value": "0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)", "purpose": "MemberCard hover lift." },
+      { "name": "card-hover-deep", "value": "0 25px 50px -12px rgb(0 0 0 / 0.25)", "purpose": "EventCard hover lift — the signature lift of the site." }
+    ],
+    "motion": [
+      { "name": "ease-out-standard", "value": "cubic-bezier(0.25, 1, 0.5, 1)", "purpose": "Default ease-out for state transitions (hover, focus, reveal)." },
+      { "name": "duration-fast", "value": "200ms", "purpose": "Color and opacity transitions on links, navs, chips." },
+      { "name": "duration-card-lift", "value": "300ms", "purpose": "Card hover transitions — scale, shadow, image zoom." },
+      { "name": "duration-hero", "value": "800ms", "purpose": "GSAP hero fade-rise (power2.out)." },
+      { "name": "carousel-sponsor", "value": "4500ms autoplay", "purpose": "Sponsor carousel auto-advance interval." },
+      { "name": "carousel-event", "value": "7000ms autoplay", "purpose": "Home page event carousel auto-advance interval." }
+    ],
+    "breakpoints": [
+      { "name": "sm", "value": "640px" },
+      { "name": "md", "value": "768px" },
+      { "name": "lg", "value": "1024px" },
+      { "name": "xl", "value": "1280px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The default call-to-action. Brand Navy fill, white text, shifts to Accent Blue Deep on hover.",
+      "html": "<button class=\"ds-btn-primary\">View events</button>",
+      "css": ".ds-btn-primary { background: #1B397E; color: #FFFFFF; padding: 12px 24px; font-family: Inter, system-ui, sans-serif; font-size: 1rem; font-weight: 600; border: none; border-radius: 8px; cursor: pointer; transition: background 200ms cubic-bezier(0.25, 1, 0.5, 1); } .ds-btn-primary:hover { background: #1D4ED8; } .ds-btn-primary:focus-visible { outline: 2px solid #2563EB; outline-offset: 2px; }"
+    },
+    {
+      "name": "Ghost Button",
+      "kind": "button",
+      "refersTo": "button-ghost",
+      "description": "Secondary action. Transparent fill, Brand Navy text, underline on hover.",
+      "html": "<button class=\"ds-btn-ghost\">Learn more</button>",
+      "css": ".ds-btn-ghost { background: transparent; color: #1B397E; padding: 12px 24px; font-family: Inter, system-ui, sans-serif; font-size: 1rem; font-weight: 600; border: none; border-radius: 8px; cursor: pointer; text-decoration: none; transition: color 200ms cubic-bezier(0.25, 1, 0.5, 1); } .ds-btn-ghost:hover { color: #1D4ED8; text-decoration: underline; text-underline-offset: 4px; } .ds-btn-ghost:focus-visible { outline: 2px solid #2563EB; outline-offset: 2px; }"
+    },
+    {
+      "name": "Category Chip — Careers",
+      "kind": "chip",
+      "refersTo": "chip-category",
+      "description": "Pill-shaped category label, overlaid on event card images. Eight categorical pairs total; Careers shown.",
+      "html": "<span class=\"ds-chip-careers\">Careers</span>",
+      "css": ".ds-chip-careers { display: inline-flex; align-items: center; background: #DBEAFE; color: #1E40AF; font-family: Inter, system-ui, sans-serif; font-size: 0.75rem; font-weight: 600; padding: 4px 12px; border-radius: 9999px; box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }"
+    },
+    {
+      "name": "Event Card",
+      "kind": "card",
+      "refersTo": "card-event",
+      "description": "Image-led card. The poster is the protagonist; card lifts on hover.",
+      "html": "<article class=\"ds-card-event\"><div class=\"ds-card-event__media\"><div class=\"ds-card-event__image\" role=\"img\" aria-label=\"Event poster\"></div><span class=\"ds-card-event__chip\">Careers</span></div><div class=\"ds-card-event__body\"><h3 class=\"ds-card-event__title\">Industry Night 2026</h3><p class=\"ds-card-event__meta\">Thu, 12 June · 6:00pm · Roundhouse</p></div></article>",
+      "css": ".ds-card-event { display: flex; flex-direction: column; background: #FFFFFF; border: 1px solid #E5E7EB; border-radius: 12px; overflow: hidden; box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1); transform: translateY(0); transition: transform 300ms cubic-bezier(0.25, 1, 0.5, 1), box-shadow 300ms cubic-bezier(0.25, 1, 0.5, 1); cursor: pointer; max-width: 360px; } .ds-card-event:hover { transform: scale(1.02); box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25); } .ds-card-event__media { position: relative; height: 224px; overflow: hidden; } .ds-card-event__image { position: absolute; inset: 0; background: linear-gradient(135deg, #1B397E 0%, #2563EB 100%); transition: transform 300ms ease-out; } .ds-card-event:hover .ds-card-event__image { transform: scale(1.1); } .ds-card-event__chip { position: absolute; top: 16px; left: 16px; background: #DBEAFE; color: #1E40AF; font-family: Inter, system-ui, sans-serif; font-size: 0.75rem; font-weight: 600; padding: 4px 12px; border-radius: 9999px; box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); } .ds-card-event__body { padding: 16px; } .ds-card-event__title { font-family: Inter, system-ui, sans-serif; font-size: 1.5rem; font-weight: 600; color: #1F2937; margin: 0 0 4px 0; line-height: 1.3; } .ds-card-event__meta { font-family: Inter, system-ui, sans-serif; font-size: 0.875rem; color: #4B5563; margin: 0; }"
+    },
+    {
+      "name": "Member Card",
+      "kind": "card",
+      "refersTo": "card-member",
+      "description": "Circular portrait + name + role. Exuberant 1.25x scale on hover — the team page is the warm-hearted chapter.",
+      "html": "<a href=\"#\" class=\"ds-card-member\" aria-label=\"View member LinkedIn\"><div class=\"ds-card-member__photo\" role=\"img\" aria-label=\"Portrait\"></div><h3 class=\"ds-card-member__name\">Alex Nguyen</h3><p class=\"ds-card-member__role\">President</p></a>",
+      "css": ".ds-card-member { display: flex; flex-direction: column; align-items: center; text-align: center; background: #FFFFFF; padding: 20px; border-radius: 12px; box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1); text-decoration: none; color: inherit; transition: transform 300ms cubic-bezier(0.25, 1, 0.5, 1), box-shadow 300ms cubic-bezier(0.25, 1, 0.5, 1); max-width: 220px; } .ds-card-member:hover { transform: scale(1.25); box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1); z-index: 1; } .ds-card-member:focus-visible { outline: 2px solid #2563EB; outline-offset: 2px; } .ds-card-member__photo { width: 96px; height: 96px; border-radius: 9999px; background: linear-gradient(135deg, #E5E7EB 0%, #D1D5DB 100%); border: 2px solid #E5E7EB; margin-bottom: 16px; } .ds-card-member__name { font-family: Inter, system-ui, sans-serif; font-size: 1.125rem; font-weight: 600; color: #1F2937; margin: 0 0 4px 0; transition: color 200ms ease-out; } .ds-card-member:hover .ds-card-member__name { color: #2563EB; } .ds-card-member__role { font-family: Inter, system-ui, sans-serif; font-size: 0.875rem; color: #4B5563; margin: 0; padding: 0 8px; }"
+    },
+    {
+      "name": "Text Input",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "Default text field. White surface, hairline border, blue ring on focus.",
+      "html": "<label class=\"ds-field\"><span class=\"ds-field__label\">Email</span><input class=\"ds-input\" type=\"email\" placeholder=\"you@unsw.edu.au\" /></label>",
+      "css": ".ds-field { display: flex; flex-direction: column; gap: 6px; max-width: 360px; } .ds-field__label { font-family: Inter, system-ui, sans-serif; font-size: 0.875rem; font-weight: 600; color: #1F2937; } .ds-input { background: #FFFFFF; border: 1px solid #E5E7EB; border-radius: 8px; padding: 12px 16px; font-family: Inter, system-ui, sans-serif; font-size: 1rem; color: #1F2937; transition: border-color 200ms ease-out, box-shadow 200ms ease-out; } .ds-input::placeholder { color: #6B7280; } .ds-input:focus-visible { outline: none; border-color: #2563EB; box-shadow: 0 0 0 3px rgb(37 99 235 / 0.25); }"
+    },
+    {
+      "name": "Nav Link — Active (Desktop)",
+      "kind": "nav",
+      "refersTo": "nav-link-active",
+      "description": "Top-nav link in its active state. No background, just brand-navy text.",
+      "html": "<nav class=\"ds-nav\"><a class=\"ds-nav__link ds-nav__link--active\" href=\"#\">Events</a><a class=\"ds-nav__link\" href=\"#\">Team</a><a class=\"ds-nav__link\" href=\"#\">Sponsors</a></nav>",
+      "css": ".ds-nav { display: flex; gap: 32px; align-items: center; } .ds-nav__link { font-family: Inter, system-ui, sans-serif; font-size: 1rem; font-weight: 600; color: #1F2937; text-decoration: none; padding: 8px 0; transition: color 200ms ease-out; } .ds-nav__link:hover { color: #1B397E; } .ds-nav__link--active { color: #1B397E; } .ds-nav__link:focus-visible { outline: 2px solid #2563EB; outline-offset: 4px; }"
+    },
+    {
+      "name": "Hero Section",
+      "kind": "custom",
+      "refersTo": "hero",
+      "description": "Photographic hero with scrim and tracked white display type. The cover of the yearbook.",
+      "html": "<section class=\"ds-hero\"><div class=\"ds-hero__photo\" role=\"img\" aria-label=\"CEUS event photo\"></div><div class=\"ds-hero__scrim\"></div><div class=\"ds-hero__inner\"><div class=\"ds-hero__title\">UNSW CEUS</div><div class=\"ds-hero__subtitle\">Chemical Engineering Undergraduate Society</div></div></section>",
+      "css": ".ds-hero { position: relative; width: 100%; height: 75vh; max-height: 600px; overflow: hidden; } .ds-hero__photo { position: absolute; inset: 0; background: linear-gradient(135deg, #1B397E 0%, #2563EB 60%, #1D4ED8 100%); } .ds-hero__scrim { position: absolute; inset: 0; background: rgba(0, 0, 0, 0.40); } .ds-hero__inner { position: relative; height: 100%; display: flex; flex-direction: column; justify-content: center; padding: 0 40px; max-width: 1200px; margin: 0 auto; color: #FFFFFF; } .ds-hero__title { font-family: Inter, system-ui, sans-serif; font-weight: 700; font-size: clamp(1.875rem, 4vw + 0.5rem, 3.125rem); line-height: 1.1; letter-spacing: 0.1875em; } .ds-hero__subtitle { font-family: Inter, system-ui, sans-serif; font-weight: 400; font-size: clamp(1.75rem, 3vw + 0.5rem, 2rem); line-height: 1.3; letter-spacing: 0.156em; margin-top: 8px; } @media (prefers-reduced-motion: no-preference) { .ds-hero__title, .ds-hero__subtitle { opacity: 0; transform: translateY(20px); animation: ds-hero-rise 800ms cubic-bezier(0.25, 1, 0.5, 1) forwards; } .ds-hero__title { animation-delay: 300ms; } .ds-hero__subtitle { animation-delay: 500ms; } } @keyframes ds-hero-rise { to { opacity: 1; transform: translateY(0); } }"
+    },
+    {
+      "name": "Footer",
+      "kind": "custom",
+      "refersTo": "footer",
+      "description": "Brand Navy strip at page foot. The single largest application of the brand color.",
+      "html": "<footer class=\"ds-footer\"><span class=\"ds-footer__copy\">© 2026 Chemical Engineering Undergraduate Society · UNSW Sydney</span></footer>",
+      "css": ".ds-footer { background: #1B397E; color: #FFFFFF; padding: 12px 20px; font-family: Inter, system-ui, sans-serif; font-size: 0.875rem; } .ds-footer__copy { display: block; text-align: center; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Engineering Society Yearbook",
+    "overview": "The CEUS site reads like a well-kept student-society yearbook: deep university navy on the cover, real photography of real students inside, generous white margins, and chapters (events, team, sponsors) you can flip through without thinking. The brand color is institutional enough that sponsors take it seriously, the photography and student-led copy keep it warm enough that a first-year doesn't feel like they're applying to grad school. Density is generous, never cramped. Cards lift and breathe on hover; pages don't shout.\n\nWhat this system rejects: the navy-and-gold institutional university-department template (dead, dense, no sense of a person behind it); the SaaS landing-page hero-metric template (we are a community, not a product launch); the corporate-finance dark-mode + gradient orb aesthetic (this is a student society, not a fintech). It also explicitly rejects clip-art / hobby-club energy: low-effort screenshots and stock illustrations don't earn sponsors' trust.",
+    "keyCharacteristics": [
+      "One serious brand color (UNSW-adjacent navy #1B397E) doing most of the identity work",
+      "Photography-led — real CEUS events, members, and labs over stock imagery",
+      "Generous white space; white surfaces with a single tinted accent (#EFF6FF)",
+      "Card-based content surfaces that lift on hover (shadow + light scale)",
+      "Single typeface (Inter), wide weight range (400 → 700) and deliberate tracking to give the hero ceremony",
+      "Categorical color used only inside event chips; never as a page-level accent"
+    ],
+    "rules": [
+      { "name": "The Brand Navy Rule", "body": "#1B397E is the only color that signals 'CEUS.' It earns its place on the footer surface, the navbar active state, and primary buttons. It is not used on backgrounds of mid-page sections, on hero scrims, or in gradients. The accent-blue family carries interactivity; the brand navy carries identity. Don't mix the two jobs.", "section": "colors" },
+      { "name": "The Categorical Cage Rule", "body": "The eight categorical color pairs exist only inside event chips. Promoting any of them to a section background, button color, or gradient stop fractures the palette and turns the site into a club hobby page.", "section": "colors" },
+      { "name": "The Single-Family Rule", "body": "Inter is the only typeface. No serif for 'warmth,' no display font for 'personality.' Personality lives in weight (400/600/700) and in the tracked hero. Adding a second family flattens the system into Generic University Microsite.", "section": "typography" },
+      { "name": "The Tracked-Hero Rule", "body": "Display and subdisplay carry wide positive tracking (~3px / ~2.5px). Every other size uses normal tracking. Tracking is the hero's job, not a general typographic effect: applying it to body or labels turns the page into a 2012 photographer portfolio.", "section": "typography" },
+      { "name": "The Lift-on-Hover Rule", "body": "Elevation is interactive, not decorative. Cards rest flat-ish, then lift. Static elevation on a non-interactive element is forbidden — it reads as nervous design.", "section": "elevation" },
+      { "name": "The No-Glassmorphism Rule", "body": "No backdrop-filter: blur, no translucent layered panes. Sponsors and faculty read the site; glass cards feel like a startup pitch deck.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do lead with real CEUS photography. Events, members, lab moments. Photography is the warmth budget.",
+      "Do reserve Brand Navy (#1B397E) for identity moments (footer, primary button, active nav). Use Accent Blue (#2563EB) for interactive accents only.",
+      "Do keep cards flat-ish at rest and let hover do the lifting (shadow-lg → shadow-xl/2xl, gentle scale).",
+      "Do keep Inter as the only typeface. Pull personality from weight (400/600/700) and the tracked hero.",
+      "Do confine the eight categorical colors to event chips only.",
+      "Do test display headings at every breakpoint. The clamp ceilings here are deliberate; if copy overflows, rewrite the copy or lower the clamp max.",
+      "Do make every motion respect prefers-reduced-motion. The GSAP hero, slick autoplay, and 1.25x member-card scale all need the reduced-motion alternative wired explicitly."
+    ],
+    "donts": [
+      "Don't put the page into navy-and-gold institutional dress. The 'generic university department' anti-reference is the single most likely failure mode for a UNSW society site.",
+      "Don't reach for the SaaS landing-page hero-metric template ('10,000+ members served'). The community is the proof, not the metric.",
+      "Don't use clip-art, stock illustrations, or generic 'students at laptops' stock photography — the hobby-club register kills sponsor trust.",
+      "Don't introduce a second typeface for 'warmth.' Inter at the right weight is the warmth.",
+      "Don't promote any categorical event color to a page-level background, gradient stop, or section accent. They live in chips, full stop.",
+      "Don't use glassmorphism, gradient orbs, or animated mesh backgrounds. Corporate-finance / fintech aesthetic is on the no-list.",
+      "Don't use border-left: 4px solid <color> as a callout accent. Use a full border or a tinted background.",
+      "Don't use gradient text (background-clip: text). Emphasis via weight or size, not color tricks.",
+      "Don't use the eyebrow / 01·02·03 numbered-section template as default scaffolding. The site has six pages — number them only if the order carries real information.",
+      "Don't let the admin UI bleed into the public site's visual language. Admin is a small product surface inside an otherwise brand site; the public visitor should never encounter or infer it."
+    ]
+  }
+}

--- a/CEUS/.impeccable/critique/2026-05-29T05-39-58Z__ceus-src-app-homeclient-tsx.md
+++ b/CEUS/.impeccable/critique/2026-05-29T05-39-58Z__ceus-src-app-homeclient-tsx.md
@@ -1,0 +1,77 @@
+---
+target: CEUS/src/app/HomeClient.tsx
+total_score: 24
+p0_count: 0
+p1_count: 4
+timestamp: 2026-05-29T05-39-58Z
+slug: ceus-src-app-homeclient-tsx
+---
+# Design Critique: `CEUS/src/app/HomeClient.tsx`
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 2 | No loading skeletons before sliders init; no current-page indicator |
+| 2 | Match System / Real World | 3 | "Happening Soon" reads natural; "About Us" copy slips into university-comms voice |
+| 3 | User Control and Freedom | 2 | Two autoplay carousels with no visible pause control; no skip-to-content |
+| 4 | Consistency and Standards | 2 | Two competing blues (brand-navy vs blue-600); CTA palette breaks system (emerald) |
+| 5 | Error Prevention | 3 | n/a — no destructive actions |
+| 6 | Recognition Rather Than Recall | 3 | Event cards and sponsor logos carry their own meaning |
+| 7 | Flexibility and Efficiency | 2 | No keyboard hints; carousel arrows clip below 1024px |
+| 8 | Aesthetic and Minimalist Design | 2 | Three flat-identical h2 headings; aphoristic intro copy; bare video block |
+| 9 | Error Recovery | 2 | Empty states are flat sentences with no CTA, no warmth |
+| 10 | Help and Documentation | 3 | Reasonable for a brand landing |
+| **Total** | | **24/40** | Acceptable — significant improvements needed |
+
+## Anti-Patterns Verdict
+
+LLM: not blatantly AI-slop (no gradient text, eyebrows, 01·02·03, glass cards). Subtler failure mode: reads as a "generic university student society site" rather than as CEUS, which is exactly the anti-reference PRODUCT.md names first.
+
+Deterministic scan: `detect.mjs` reported 0 findings. The issues are compositional and strategic.
+
+## Priority Issues
+
+### [P1] The hero is brand-shouting, not user-leading
+Hero text "UNSW CEUS / Chemical Engineering Undergraduate Society" tells the visitor what they already know. **Zero CTA in the hero.** Fix: replace subtitle with concrete promise tied to next event OR add a single Brand Navy primary CTA. Command: `/impeccable shape hero-lede` or `/impeccable clarify`.
+
+### [P1] About Us copy is the exact university-comms voice PRODUCT.md rejects
+Lines 125-127: "vibrant, student-run organisation / enrich the university experience / fosters connection, collaboration, and a strong sense of belonging" — none of "student-led, credible, warm." Cut to one paragraph in student voice. Demote section below event slider. Command: `/impeccable clarify`.
+
+### [P1] Section order violates Design Principle 2 ("next event is the lede")
+Current: Hero → About (3 paragraphs) → Happening Soon. Events sit ~2.5 viewports below fold on mobile. Reorder: Hero → Happening Soon → Sponsors → Video → About. Command: `/impeccable layout`.
+
+### [P1] CTA palette breaks the design system in two ways
+Line 144: "View All Events" uses `bg-blue-600` (should be Brand Navy `#1B397E` per spec). Line 147: "Subscribe to Calendar" uses `bg-emerald-600` (out of palette entirely). Result: no primary action. Fix: View All Events → Brand Navy. Subscribe → Ghost button. Command: `/impeccable polish`.
+
+### [P2] Heading hierarchy is flat — every h2 is `text-4xl md:text-5xl font-bold text-center`
+No signal which section is priority. Make "Happening Soon" loudest; demote "About Us" and "Our Sponsors". Hierarchy through scale + weight contrast (≥1.25 ratio). Command: `/impeccable typeset`.
+
+### [P2] Empty states lack warmth and remediation
+"No sponsors to display right now." violates PRODUCT.md Design Principle 3 ("Sponsors get dignity"). Both empty states need photographic element, brand voice, real CTA. Sponsor empty state: *"Looking for industry partners for 2026 — let's talk."* + contact CTA. Command: `/impeccable onboard`.
+
+### [P2] GSAP hero animation has no `prefers-reduced-motion` guard
+Sam (a11y) sees fade+rise regardless. Worse: `fromTo` initial opacity:0 — JS failure window. Fix: wrap timeline in motion-no-preference check; default markup visible. Command: `/impeccable animate` or `/impeccable harden`.
+
+## Persona Red Flags
+
+**Jordan (First-Timer):** ~30s of scroll before reaching first useful info. No CTA above fold. No visible "join CEUS" entry point on home page.
+
+**Casey (Mobile):** Hero `h-[75vh]` then ~2 screens of About prose before events. Two same-weight CTAs in different palette colors force unwanted choice.
+
+**Sam (a11y):** GSAP ignores reduced motion. Slick autoplay (4.5s/7s) doesn't either. Carousel arrows positioned `-50px/-30px/-20px` outside viewport at mobile breakpoints. Hero scrim 40% may underdeliver on subtitle contrast.
+
+## Minor Observations
+
+- Video section line 179 has no heading or caption — bare black rectangle.
+- `bg-black/5` (line 177) is the worst of both — neither commit nor invisible.
+- Subscribe to Calendar URL is a 100-char opaque ID inline in JSX.
+- Section heading alignment is mixed: "About Us" h2 centered, paragraphs `text-left`.
+- Hero subtitle `tracking-[2.5px]` on `font-normal` 28-32px Inter is overstyled at body weight.
+
+## Questions to Consider
+
+- What would a visitor who has never heard of CEUS see in the hero? Right now: the brand name.
+- Does this page need "About Us" at all, or just a one-paragraph who-we-are at the bottom?
+- What if `Happening Soon` and the empty state were the same component (a persistent "next event" that degrades to "what we're planning")?
+- What's the page doing that a sponsor wants to see?

--- a/CEUS/.impeccable/critique/2026-05-29T10-44-46Z__ceus-src-app-homeclient-tsx.md
+++ b/CEUS/.impeccable/critique/2026-05-29T10-44-46Z__ceus-src-app-homeclient-tsx.md
@@ -1,0 +1,67 @@
+---
+target: CEUS/src/app/HomeClient.tsx
+total_score: 33
+p0_count: 0
+p1_count: 0
+timestamp: 2026-05-29T10-44-46Z
+slug: ceus-src-app-homeclient-tsx
+---
+# Design Critique: `CEUS/src/app/HomeClient.tsx` (post-rewrite)
+
+## Design Health Score
+
+| # | Heuristic | Score | Δ | Key Issue |
+|---|-----------|-------|---|-----------|
+| 1 | Visibility of System Status | 3 | +1 | Hierarchy signals lede; no global loading skeleton |
+| 2 | Match System / Real World | 4 | +1 | About copy in real student voice; "Happening Soon" is honest |
+| 3 | User Control and Freedom | 3 | +1 | Anchor nav works; carousels still autoplay without pause control |
+| 4 | Consistency and Standards | 4 | +2 | Every CTA is Brand Navy primary or Brand Navy ghost |
+| 5 | Error Prevention | 3 | 0 | n/a |
+| 6 | Recognition Rather Than Recall | 3 | 0 | Event cards / sponsor logos still carry recognition |
+| 7 | Flexibility and Efficiency | 3 | +1 | Anchor nav from hero, focus-visible rings everywhere |
+| 8 | Aesthetic and Minimalist Design | 4 | +2 | Hierarchy compressed, wall of text gone |
+| 9 | Error Recovery | 3 | +1 | Both empty states have brand-voice copy + CTA |
+| 10 | Help and Documentation | 3 | 0 | Reasonable for a brand landing |
+| **Total** | | **33/40** | **+9** | **Good — solid foundation, address weak areas** |
+
+## Anti-Patterns Verdict
+
+Page reads like CEUS now. Hero answers "why am I here?", lede is the lede, copy doesn't try to be vibrant, palette doesn't fight itself. Detector 0 findings.
+
+## Priority Issues
+
+### [P2] Slick autoplay lacks reduced-motion guard
+Sponsor 4.5s, events 7s, no visible pause control. GSAP hero is now guarded but autoplay isn't. Fix: detect `prefers-reduced-motion` and set `autoplay: false`, or add a visible toggle. Command: `/impeccable animate`.
+
+### [P2] Hero subtitle contrast may be borderline on photographic backgrounds
+`text-white/90` at body weight over `bg-black/45` scrim on a UNSW Ball photo. Bright parts of the photo may drop subtitle below 4.5:1. Fix: drop the /90 opacity, keep scrim. Command: `/impeccable polish`.
+
+### [P3] No smooth-scroll for anchor links
+Hero CTAs anchor-link to sections — page jumps instantly. Fix: add `scroll-behavior: smooth` to html selector in index.css.
+
+### [P3] Video section title is a guess
+"A look at CEUS" — I don't know what videoId="x3DD5gMo3fA" actually contains. Replace with real title.
+
+### [P3] Hero secondary CTA "About CEUS" deep-links to same page
+User can reach About by scrolling, which primary CTA already invites. Hero is busier than needed. Fix: remove secondary CTA. Command: `/impeccable distill`.
+
+## Persona Red Flags
+
+**Jordan:** Major improvement — concrete promise, clear next action. Remaining gap: no "How do I join?" path.
+
+**Casey:** Hero now denser (4 elements). Smooth-scroll would help mobile anchor taps feel intentional.
+
+**Sam:** h1 added (was missing), GSAP guard ✓, focus rings ✓. Slick autoplay still un-guarded. Skip-to-content link still missing at layout level.
+
+## Minor Observations
+
+- About section is short (one paragraph). If `/about` is also sparse, the home page is the only place visitors meet the society's story.
+- `text-wrap: balance` via inline style; could use Tailwind's `text-balance` utility.
+- Hero title uses fixed-step responsive sizes instead of fluid `clamp()`.
+- Slick global styles still in `<style jsx global>` in the JSX file. Could move to index.css.
+
+## Questions to Consider
+
+- How do people *join* CEUS? Page tells what's happening but no "Join" CTA.
+- Should the video be higher in the page (between hero and events) as an emotional moment?
+- Should the sponsor carousel be a static logo strip instead? Auto-rotation hides logos from users who don't wait.

--- a/CEUS/src/app/HomeClient.tsx
+++ b/CEUS/src/app/HomeClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 // src/app/HomeClient.tsx
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import gsap from 'gsap';
 import Slider from 'react-slick';
 import type { CustomArrowProps, Settings } from 'react-slick';
@@ -10,9 +10,35 @@ import Link from 'next/link';
 import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
 import LazyYouTube from '../components/LazyYouTube';
 import { STATIC_ASSET_URLS } from '../lib/storagePublicUrls';
+import { CALENDAR_SUBSCRIBE_URL } from '../lib/links';
 import { Event, Sponsor } from '../types';
 import EventCard from '../components/EventCard';
 import OptimizedImage from '../components/OptimizedImage';
+
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+const PrevArrow = (props: CustomArrowProps) => (
+  <div
+    className={props.className}
+    style={{ ...props.style, display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1 }}
+    onClick={props.onClick}
+    aria-label="Previous"
+  >
+    <FaChevronLeft className="text-2xl text-[#1B397E]" />
+  </div>
+);
+
+const NextArrow = (props: CustomArrowProps) => (
+  <div
+    className={props.className}
+    style={{ ...props.style, display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1 }}
+    onClick={props.onClick}
+    aria-label="Next"
+  >
+    <FaChevronRight className="text-2xl text-[#1B397E]" />
+  </div>
+);
 
 interface HomeClientProps {
   events: Event[];
@@ -20,23 +46,47 @@ interface HomeClientProps {
 }
 
 const HomeClient: React.FC<HomeClientProps> = ({ events, sponsors }) => {
-  const heroTitleRef = useRef<HTMLDivElement>(null);
-  const heroSubtitleRef = useRef<HTMLDivElement>(null);
+  const heroTitleRef = useRef<HTMLHeadingElement>(null);
+  const heroSubtitleRef = useRef<HTMLParagraphElement>(null);
+  const heroCtaRef = useRef<HTMLDivElement>(null);
 
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   useEffect(() => {
-    if (heroTitleRef.current && heroSubtitleRef.current) {
-      const tl = gsap.timeline({ defaults: { duration: 0.8, ease: 'power2.out' } });
-      tl.fromTo(heroTitleRef.current, 
-        { opacity: 0, y: 20 },
-        { opacity: 1, y: 0, delay: 0.3 }
-      ); 
-      tl.fromTo(heroSubtitleRef.current, 
-        { opacity: 0, y: 20 },
-        { opacity: 1, y: 0 },
-        "-=0.6"
-      ); 
-      return () => { tl.kill(); };
-    }
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time sync of an external (matchMedia) value into state on mount; subsequent updates come from the 'change' listener below
+    setPrefersReducedMotion(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setPrefersReducedMotion(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!heroTitleRef.current || !heroSubtitleRef.current || !heroCtaRef.current) return;
+    const prefersReducedMotion =
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (prefersReducedMotion) return;
+
+    const tl = gsap.timeline({ defaults: { duration: 0.8, ease: 'power3.out' } });
+    tl.fromTo(
+      heroTitleRef.current,
+      { opacity: 0, y: 24 },
+      { opacity: 1, y: 0, delay: 0.2 }
+    );
+    tl.fromTo(
+      heroSubtitleRef.current,
+      { opacity: 0, y: 16 },
+      { opacity: 1, y: 0 },
+      '-=0.55'
+    );
+    tl.fromTo(
+      heroCtaRef.current,
+      { opacity: 0, y: 12 },
+      { opacity: 1, y: 0 },
+      '-=0.5'
+    );
+    return () => {
+      tl.kill();
+    };
   }, []);
 
   const now = new Date();
@@ -48,18 +98,6 @@ const HomeClient: React.FC<HomeClientProps> = ({ events, sponsors }) => {
     return eventDate >= now && eventDate <= twoWeeksFromNow;
   });
 
-  const PrevArrow = (props: CustomArrowProps) => (
-    <div className={props.className} style={{ ...props.style, display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1 }} onClick={props.onClick} aria-label="Previous">
-      <FaChevronLeft className="text-blue-600 text-2xl" />
-    </div>
-  );
-
-  const NextArrow = (props: CustomArrowProps) => (
-    <div className={props.className} style={{ ...props.style, display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1 }} onClick={props.onClick} aria-label="Next">
-      <FaChevronRight className="text-blue-600 text-2xl" />
-    </div>
-  );
-
   const sponsorSettings: Settings = {
     dots: true,
     arrows: true,
@@ -68,68 +106,81 @@ const HomeClient: React.FC<HomeClientProps> = ({ events, sponsors }) => {
     infinite: sponsors.length > 3,
     slidesToShow: 3,
     slidesToScroll: 1,
-    autoplay: true,
+    autoplay: !prefersReducedMotion,
     autoplaySpeed: 4500,
     pauseOnHover: true,
     centerMode: sponsors.length < 3,
-    centerPadding: "40px",
+    centerPadding: '40px',
     responsive: [
       { breakpoint: 1024, settings: { slidesToShow: 4, centerMode: false, arrows: true } },
       { breakpoint: 600, settings: { slidesToShow: 3, centerMode: false, arrows: true } },
-      { breakpoint: 480, settings: { slidesToShow: 2, centerMode: false, arrows: true } }
-    ]
+      { breakpoint: 480, settings: { slidesToShow: 2, centerMode: false, arrows: true } },
+    ],
   };
 
   const eventSettings: Settings = {
     dots: true,
     infinite: upcomingEventsNextTwoWeeks.length > 3,
-    slidesToShow: 3, 
+    slidesToShow: 3,
     slidesToScroll: 1,
-    autoplay: true,
+    autoplay: !prefersReducedMotion,
     autoplaySpeed: 7000,
     pauseOnHover: true,
     responsive: [
       { breakpoint: 1024, settings: { slidesToShow: 2, slidesToScroll: 1, infinite: upcomingEventsNextTwoWeeks.length > 2, dots: true } },
-      { breakpoint: 600, settings: { slidesToShow: 1, slidesToScroll: 1, initialSlide: 0, infinite: upcomingEventsNextTwoWeeks.length > 1 } }
-    ]
+      { breakpoint: 600, settings: { slidesToShow: 1, slidesToScroll: 1, initialSlide: 0, infinite: upcomingEventsNextTwoWeeks.length > 1 } },
+    ],
   };
 
   return (
-    <> 
-      <section className="relative w-full h-[75vh] max-h-[600px] overflow-hidden"> 
-        <OptimizedImage 
+    <>
+      {/* Hero */}
+      <section className="relative w-full h-[80vh] max-h-[640px] overflow-hidden">
+        <OptimizedImage
           src={STATIC_ASSET_URLS.heroBackground}
-          alt="CEUS Ball Group Photo" 
+          alt="CEUS members at the annual Engineering Ball"
           fill
           priority
-          className="object-cover object-center" 
+          className="object-cover object-center"
           containerClassName="absolute inset-0"
         />
-        <div className="absolute inset-0 bg-black/40 z-10"></div>
-        
-        <div className="relative z-20 h-full flex items-center container mx-auto px-4"> 
-          <div className="text-white text-left"> 
-            <div ref={heroTitleRef} className="text-[30px] md:text-[50px] font-bold tracking-[3px] leading-tight"> 
+        <div className="absolute inset-0 bg-black/45 z-10" />
+
+        <div className="relative z-20 h-full flex items-center container mx-auto px-4 md:px-6">
+          <div className="text-white text-left max-w-3xl">
+            <h1
+              ref={heroTitleRef}
+              className="text-[36px] md:text-[60px] lg:text-[76px] font-bold leading-[1.05] tracking-[0.14em]"
+            >
               UNSW CEUS
-            </div>
-            <div ref={heroSubtitleRef} className="text-[28px] md:text-[32px] font-normal tracking-[2.5px] leading-snug">
-               Chemical Engineering Undergraduate Society
+            </h1>
+            <p
+              ref={heroSubtitleRef}
+              className="mt-4 md:mt-5 max-w-2xl text-lg md:text-2xl font-normal leading-snug text-white"
+            >
+              Events, industry connections, and the people you&apos;ll meet along the way.
+            </p>
+            <div ref={heroCtaRef} className="mt-8 md:mt-10 flex flex-wrap gap-3">
+              <Link
+                href="#happening"
+                className="inline-flex items-center justify-center rounded-lg bg-[#1B397E] px-7 py-3 text-base font-semibold text-white transition-colors duration-200 ease-out hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black/30"
+              >
+                See what&apos;s on
+              </Link>
             </div>
           </div>
         </div>
       </section>
 
-      <section className="container mx-auto px-4 py-16 md:py-24 text-left">
-        <h2 className="text-4xl md:text-5xl font-bold mb-16 text-center">About Us</h2>
-        <div className="text-xl text-gray-600 leading-relaxed max-w-5xl mx-auto space-y-6">
-          <p>Welcome to the Chemical Engineering Undergraduate Society (CEUS)! We are a vibrant, student-run organisation representing all students within the School of Chemical Engineering at the University of New South Wales (UNSW).</p>
-          <p>Our mission is to enrich the university experience by supporting the academic, social, and professional growth of our members. Through a diverse range of events, industry networking opportunities, and community initiatives, CEUS fosters connection, collaboration, and a strong sense of belonging among chemical engineering students.</p>
-          <p>Whether you’re looking to build your career, meet like-minded peers, or simply make the most of your time at UNSW, CEUS is here to help you get involved and thrive.</p>
-        </div>
-      </section>
-      
-      <section className="container mx-auto px-4 py-16 md:py-24">
-        <h2 className="text-4xl md:text-5xl font-bold text-center mb-10">Happening Soon</h2>
+      {/* Happening Soon — the lede */}
+      <section id="happening" className="container mx-auto px-4 py-16 md:py-24 scroll-mt-20">
+        <h2 className="text-4xl md:text-5xl lg:text-6xl font-bold text-center text-gray-900 mb-3" style={{ textWrap: 'balance' } as React.CSSProperties}>
+          Happening Soon
+        </h2>
+        <p className="text-center text-base md:text-lg text-gray-600 mb-12 max-w-xl mx-auto">
+          What&apos;s coming up in the next two weeks.
+        </p>
+
         {upcomingEventsNextTwoWeeks.length > 0 ? (
           <Slider {...eventSettings}>
             {upcomingEventsNextTwoWeeks.map(event => (
@@ -137,29 +188,50 @@ const HomeClient: React.FC<HomeClientProps> = ({ events, sponsors }) => {
             ))}
           </Slider>
         ) : (
-          <p className="text-center text-gray-600 text-lg">No events scheduled for the next two weeks. Check out the full calendar on our events page!</p>
+          <div className="mx-auto max-w-xl rounded-xl border border-gray-200 bg-gray-50 px-8 py-10 md:px-12 md:py-14 text-center">
+            <p className="text-lg text-gray-700 mb-6">
+              Nothing in the next two weeks. The term calendar has what&apos;s coming up next.
+            </p>
+            <Link
+              href="/events"
+              className="inline-flex items-center justify-center rounded-lg bg-[#1B397E] px-6 py-3 text-sm font-semibold text-white transition-colors duration-200 ease-out hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+            >
+              See the full calendar
+            </Link>
+          </div>
         )}
 
-        <div className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
-          <Link href="/events" className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-8 rounded-lg transition duration-300 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
-            View All Events
+        <div className="mt-12 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+          <Link
+            href="/events"
+            className="inline-flex w-full items-center justify-center rounded-lg bg-[#1B397E] px-7 py-3 text-base font-semibold text-white transition-colors duration-200 ease-out hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 sm:w-auto"
+          >
+            View all events
           </Link>
-          <a href="https://calendar.google.com/calendar/u/0?cid=ZWIwYjViOTgxYjJmMGE5NDM0NzczNjMzODU1MGRkZGFiMTYwMmQ1NDE2MTI5MjQ5ZmQzNzczZjQzNjQxYjlhN0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t" target="_blank" rel="noopener noreferrer" className="inline-block bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-3 px-8 rounded-lg transition duration-300 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2">
-            Subscribe to Calendar
+          <a
+            href={CALENDAR_SUBSCRIBE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex w-full items-center justify-center rounded-lg border-2 border-[#1B397E] bg-transparent px-7 py-3 text-base font-semibold text-[#1B397E] transition-colors duration-200 ease-out hover:bg-[#1B397E]/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 sm:w-auto"
+          >
+            Subscribe to calendar
           </a>
         </div>
       </section>
 
-      <section className="container mx-auto px-4 py-16 md:py-24">
-        <h2 className="text-4xl md:text-5xl font-bold text-center mb-10">Our Sponsors</h2>
+      {/* Our Sponsors */}
+      <section id="sponsors" className="container mx-auto px-4 py-16 md:py-20 scroll-mt-20">
+        <h2 className="text-3xl md:text-4xl font-bold text-center text-gray-900 mb-10">
+          Our Sponsors
+        </h2>
         {sponsors.length > 0 ? (
           <div className="relative">
             <Slider {...sponsorSettings}>
               {sponsors.map(sponsor => (
                 <div key={sponsor.id} className="px-4">
-                  <OptimizedImage 
-                    src={sponsor.logoUrl} 
-                    alt={sponsor.name} 
+                  <OptimizedImage
+                    src={sponsor.logoUrl}
+                    alt={sponsor.name}
                     width={140}
                     height={140}
                     objectFit="contain"
@@ -170,15 +242,45 @@ const HomeClient: React.FC<HomeClientProps> = ({ events, sponsors }) => {
             </Slider>
           </div>
         ) : (
-          <p className="text-center text-gray-600 text-lg">No sponsors to display right now.</p>
+          <div className="mx-auto max-w-2xl rounded-xl border border-gray-200 bg-gray-50 px-8 py-10 md:px-12 md:py-14 text-center">
+            <p className="text-lg font-semibold text-gray-900 mb-2">
+              Looking for industry partners for 2026.
+            </p>
+            <p className="text-base text-gray-700 mb-6">
+              If your team recruits chemical engineering students, let&apos;s talk.
+            </p>
+            <Link
+              href="/contact"
+              className="inline-flex items-center justify-center rounded-lg bg-[#1B397E] px-6 py-3 text-sm font-semibold text-white transition-colors duration-200 ease-out hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+            >
+              Get in touch
+            </Link>
+          </div>
         )}
       </section>
 
-      <section className="bg-black/5 py-8 md:py-12 lg:py-16 px-4 md:px-6"> 
-        <div className="container mx-auto max-w-6xl">
-          <div className="relative w-full aspect-video rounded-lg overflow-hidden shadow-2xl">
+      {/* Video */}
+      <section className="container mx-auto px-4 py-16 md:py-20">
+        <div className="max-w-5xl mx-auto">
+          {/* TODO: Confirm with team — heading is a placeholder until the video subject is verified. */}
+          <h2 className="text-3xl md:text-4xl font-bold text-center text-gray-900 mb-8">
+            A look at CEUS
+          </h2>
+          <div className="relative w-full aspect-video rounded-xl overflow-hidden shadow-xl">
             <LazyYouTube videoId="x3DD5gMo3fA" title="CEUS UNSW Video" />
           </div>
+        </div>
+      </section>
+
+      {/* About — moved to bottom for visitors who want the longer story */}
+      <section id="about" className="container mx-auto px-4 py-16 md:py-24 scroll-mt-20">
+        <div className="max-w-3xl mx-auto">
+          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-6">
+            About CEUS
+          </h2>
+          <p className="text-lg text-gray-700 leading-relaxed">
+            We&apos;re the student-run society for chemical engineering at UNSW. Industry nights with engineers working in process design, social lawn days, mid-semester study sessions, and the annual Engineering Ball. If you&apos;re in the school, you&apos;re already part of us.
+          </p>
         </div>
       </section>
 
@@ -192,12 +294,16 @@ const HomeClient: React.FC<HomeClientProps> = ({ events, sponsors }) => {
           display: flex !important;
           align-items: center;
           justify-content: center;
-          transition: all 0.3s ease !important;
+          transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease !important;
         }
         .slick-prev:hover, .slick-next:hover {
           background: #f3f4f6 !important;
           box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2) !important;
-          transform: scale(1.1);
+        }
+        @media (prefers-reduced-motion: no-preference) {
+          .slick-prev:hover, .slick-next:hover {
+            transform: scale(1.08);
+          }
         }
         .slick-prev { left: -50px !important; }
         .slick-next { right: -50px !important; }

--- a/CEUS/src/index.css
+++ b/CEUS/src/index.css
@@ -3,4 +3,33 @@
 @tailwind components;
 @tailwind utilities;
 
-/* NO OTHER CSS RULES SHOULD BE IN THIS FILE */
+@layer base {
+  html {
+    scroll-behavior: smooth;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+  }
+}
+
+@layer utilities {
+  @keyframes fadeInUp {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    .animate-fade-in-up {
+      animation: fadeInUp 0.5s ease-out forwards;
+    }
+  }
+}
+
+/* Keep this file minimal — global rules only; component styles belong in Tailwind classes or component files. */

--- a/CEUS/src/lib/links.ts
+++ b/CEUS/src/lib/links.ts
@@ -1,0 +1,5 @@
+// Shared external links used by multiple pages.
+// Hoisted here so a URL change is a one-line edit rather than a multi-file hunt.
+
+export const CALENDAR_SUBSCRIBE_URL =
+  'https://calendar.google.com/calendar/u/0?cid=ZWIwYjViOTgxYjJmMGE5NDM0NzczNjMzODU1MGRkZGFiMTYwMmQ1NDE2MTI5MjQ5ZmQzNzczZjQzNjQxYjlhN0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t';

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,296 @@
+---
+name: CEUS Website
+description: Visual system for the UNSW Chemical Engineering Undergraduate Society website.
+colors:
+  brand-navy: "#1B397E"
+  accent-blue: "#2563EB"
+  accent-blue-deep: "#1D4ED8"
+  surface-white: "#FFFFFF"
+  surface-tint-blue: "#EFF6FF"
+  ink-strong: "#1F2937"
+  ink-body: "#374151"
+  ink-muted: "#4B5563"
+  ink-soft: "#6B7280"
+  hairline: "#E5E7EB"
+  scrim: "rgba(0, 0, 0, 0.40)"
+  scrim-strong: "rgba(0, 0, 0, 0.70)"
+  category-flagship-bg: "#F3E8FF"
+  category-flagship-ink: "#6B21A8"
+  category-careers-bg: "#DBEAFE"
+  category-careers-ink: "#1E40AF"
+  category-social-bg: "#DCFCE7"
+  category-social-ink: "#166534"
+  category-academic-bg: "#FFEDD5"
+  category-academic-ink: "#9A3412"
+  category-welfare-bg: "#FCE7F3"
+  category-welfare-ink: "#9D174D"
+  category-recruitment-bg: "#E0E7FF"
+  category-recruitment-ink: "#3730A3"
+  category-collab-bg: "#CCFBF1"
+  category-collab-ink: "#115E59"
+  category-other-bg: "#F3F4F6"
+  category-other-ink: "#1F2937"
+typography:
+  display:
+    fontFamily: "Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
+    fontSize: "clamp(1.875rem, 4vw + 0.5rem, 3.125rem)"
+    fontWeight: 700
+    lineHeight: 1.1
+    letterSpacing: "0.1875em"
+  subdisplay:
+    fontFamily: "Inter, system-ui, sans-serif"
+    fontSize: "clamp(1.75rem, 3vw + 0.5rem, 2rem)"
+    fontWeight: 400
+    lineHeight: 1.3
+    letterSpacing: "0.156em"
+  headline:
+    fontFamily: "Inter, system-ui, sans-serif"
+    fontSize: "clamp(2.25rem, 3vw, 3rem)"
+    fontWeight: 700
+    lineHeight: 1.15
+    letterSpacing: "normal"
+  title:
+    fontFamily: "Inter, system-ui, sans-serif"
+    fontSize: "1.5rem"
+    fontWeight: 600
+    lineHeight: 1.3
+    letterSpacing: "normal"
+  body:
+    fontFamily: "Inter, system-ui, sans-serif"
+    fontSize: "1rem"
+    fontWeight: 400
+    lineHeight: 1.6
+    letterSpacing: "normal"
+  label:
+    fontFamily: "Inter, system-ui, sans-serif"
+    fontSize: "0.75rem"
+    fontWeight: 600
+    lineHeight: 1
+    letterSpacing: "normal"
+rounded:
+  sm: "6px"
+  md: "8px"
+  lg: "12px"
+  pill: "9999px"
+spacing:
+  xs: "8px"
+  sm: "12px"
+  md: "16px"
+  lg: "24px"
+  xl: "40px"
+  hero: "75vh"
+components:
+  button-primary:
+    backgroundColor: "{colors.brand-navy}"
+    textColor: "{colors.surface-white}"
+    rounded: "{rounded.md}"
+    padding: "12px 24px"
+    typography: "{typography.title}"
+  button-primary-hover:
+    backgroundColor: "{colors.accent-blue-deep}"
+    textColor: "{colors.surface-white}"
+  button-ghost:
+    backgroundColor: "transparent"
+    textColor: "{colors.brand-navy}"
+    rounded: "{rounded.md}"
+    padding: "12px 24px"
+  card-event:
+    backgroundColor: "{colors.surface-white}"
+    rounded: "{rounded.lg}"
+    padding: "0"
+  card-member:
+    backgroundColor: "{colors.surface-white}"
+    rounded: "{rounded.lg}"
+    padding: "20px"
+  chip-category:
+    rounded: "{rounded.pill}"
+    padding: "4px 12px"
+    typography: "{typography.label}"
+  nav-link:
+    textColor: "{colors.ink-strong}"
+    typography: "{typography.body}"
+  nav-link-active:
+    textColor: "{colors.brand-navy}"
+    backgroundColor: "{colors.surface-tint-blue}"
+  footer:
+    backgroundColor: "{colors.brand-navy}"
+    textColor: "{colors.surface-white}"
+    padding: "12px 20px"
+  hero-overlay:
+    backgroundColor: "{colors.scrim}"
+    textColor: "{colors.surface-white}"
+---
+
+# Design System: CEUS Website
+
+## 1. Overview
+
+**Creative North Star: "The Engineering Society Yearbook"**
+
+The CEUS site reads like a well-kept student-society yearbook: deep university navy on the cover, real photography of real students inside, generous white margins, and chapters (events, team, sponsors) you can flip through without thinking. The brand color is institutional enough that sponsors take it seriously, the photography and student-led copy keep it warm enough that a first-year doesn't feel like they're applying to grad school. Density is generous, never cramped. Cards lift and breathe on hover; pages don't shout.
+
+What this system rejects: the navy-and-gold institutional university-department template (dead, dense, no sense of a person behind it); the SaaS landing-page hero-metric template (we are a community, not a product launch); the corporate-finance dark-mode + gradient orb aesthetic (this is a student society, not a fintech). It also explicitly rejects clip-art / hobby-club energy: low-effort screenshots and stock illustrations don't earn sponsors' trust.
+
+**Key Characteristics:**
+- One serious brand color (UNSW-adjacent navy `#1B397E`) doing most of the identity work
+- Photography-led — real CEUS events, members, and labs over stock imagery
+- Generous white space; white surfaces with a single tinted accent (`#EFF6FF`)
+- Card-based content surfaces that lift on hover (shadow + light scale)
+- Single typeface (Inter), wide weight range (400 → 700) and deliberate tracking to give the hero ceremony
+- Categorical color used only inside event chips; never as a page-level accent
+
+## 2. Colors: The Yearbook Cover Palette
+
+The palette is a single saturated brand navy carrying the identity, a near-twin blue carrying interactive accents, and an eight-color categorical set reserved for event chips and nothing else.
+
+### Primary
+- **Brand Navy** (`#1B397E`): UNSW-adjacent deep navy. The single most important color in the system. Used on the footer surface, navbar active state, and any element that signals "this is CEUS, not the university." It is the cover color of the yearbook.
+
+### Secondary
+- **Accent Blue** (`#2563EB` — Tailwind `blue-600`): A brighter, more interactive blue used for link hovers, focus ring tints, "view more" affordances, and progressive-disclosure cues. It is *not* the brand color; it is the click-target color.
+- **Accent Blue Deep** (`#1D4ED8` — `blue-700`): Hover state for accent-blue elements.
+- **Surface Tint Blue** (`#EFF6FF` — `blue-50`): The only colored surface in the system. Used as the active-state background under the mobile nav link. Never as a section background.
+
+### Neutral
+- **Surface White** (`#FFFFFF`): All page surfaces, all card surfaces, all input surfaces. The yearbook's paper.
+- **Ink Strong** (`#1F2937` — `gray-800`): Card titles, headings, foregrounds where the design wants weight.
+- **Ink Body** (`#374151` — `gray-700`): Default body copy.
+- **Ink Muted** (`#4B5563` — `gray-600`): Member roles, dates, supporting metadata.
+- **Ink Soft** (`#6B7280` — `gray-500`): Placeholder text, icon-only controls, tertiary captions.
+- **Hairline** (`#E5E7EB` — `gray-200`): Card borders, dividers. Always 1px.
+- **Scrim** (`rgba(0,0,0,0.40)`): Hero photo overlay so white display type stays legible.
+- **Scrim Strong** (`rgba(0,0,0,0.70)`): Hover-reveal overlay on home event cards.
+
+### Categorical (event chips only)
+Eight ` *-100 / *-800` pairs, drawn from Tailwind's palette. Each pair labels one event category and exists only inside the category chip — never as a section accent, gradient stop, or page background.
+
+| Category | Background | Ink |
+|---|---|---|
+| Flagship | `#F3E8FF` | `#6B21A8` |
+| Careers | `#DBEAFE` | `#1E40AF` |
+| Social | `#DCFCE7` | `#166534` |
+| Academic | `#FFEDD5` | `#9A3412` |
+| Welfare | `#FCE7F3` | `#9D174D` |
+| Recruitment | `#E0E7FF` | `#3730A3` |
+| Collaboration | `#CCFBF1` | `#115E59` |
+| Other | `#F3F4F6` | `#1F2937` |
+
+### Named Rules
+
+**The Brand Navy Rule.** `#1B397E` is the only color that signals "CEUS." It earns its place on the footer surface, the navbar active state, and primary buttons. It is *not* used on backgrounds of mid-page sections, on hero scrims, or in gradients. The accent-blue family carries interactivity; the brand navy carries identity. Don't mix the two jobs.
+
+**The Categorical Cage Rule.** The eight categorical color pairs exist only inside event chips. Promoting any of them to a section background, button color, or gradient stop fractures the palette and turns the site into a club hobby page.
+
+## 3. Typography
+
+**Display & Body Font:** Inter (with `system-ui, -apple-system, Segoe UI, Roboto, sans-serif` fallbacks).
+
+**Character:** One typeface, wide range. Inter is neutral, legible, and unfussy — the right call for a student society that needs to feel both credible and approachable. Personality is carried by *weight contrast* (400 vs. 700) and by *deliberate letter-spacing* on display sizes, not by adding a second family.
+
+### Hierarchy
+
+- **Display** (Inter 700, `clamp(1.875rem, 4vw + 0.5rem, 3.125rem)`, line-height 1.1, tracking `0.1875em` / ~3px): The hero title "UNSW CEUS." Wide tracking is the ceremony move — gives the brand wordmark on the homepage a yearbook-cover bearing.
+- **Subdisplay** (Inter 400, `clamp(1.75rem, 3vw + 0.5rem, 2rem)`, tracking `0.156em` / ~2.5px): The hero subtitle "Chemical Engineering Undergraduate Society." Light weight against the bold display creates the contrast.
+- **Headline** (Inter 700, `clamp(2.25rem, 3vw, 3rem)`, line-height 1.15): Page-level h2 on /about, /sponsors, /team — the "Interested in Sponsoring CEUS?" register.
+- **Title** (Inter 600, `1.5rem`, line-height 1.3): Card titles. Event names, member names, sponsor names inside cards.
+- **Body** (Inter 400, `1rem` / 16px, line-height 1.6): Default paragraph text. Capped at 65–75ch in long-form sections.
+- **Label** (Inter 600, `0.75rem` / 12px, line-height 1): Category chips, metadata badges. Sentence case, not uppercase.
+
+### Named Rules
+
+**The Single-Family Rule.** Inter is the only typeface. No serif for "warmth," no display font for "personality." Personality lives in weight (400/600/700) and in the tracked hero. Adding a second family flattens the system into Generic University Microsite.
+
+**The Tracked-Hero Rule.** Display and subdisplay carry wide positive tracking (~3px / ~2.5px). Every other size uses normal tracking. Tracking is the hero's job, not a general typographic effect: applying it to body or labels turns the page into a 2012 photographer portfolio.
+
+## 4. Elevation
+
+The system is **flat-by-default with state-driven elevation**. Surfaces sit on the page with no shadow at rest, except for cards and the header (which carry a baseline `shadow-sm` / `shadow-lg` to separate them from the page). Depth arrives on hover: cards lift via shadow growth + a small scale transform, signalling "this is the click target." There is no ambient drop-shadow language on buttons, inputs, or chips.
+
+### Shadow Vocabulary
+
+- **Header rest** (`box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05)`): The white site header, separating it from white page surfaces.
+- **Card rest** (`box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)` — Tailwind `shadow-lg`): The default for event and member cards. Enough to read as a card without dominating.
+- **Card hover, primary** (`box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)` — `shadow-xl`): MemberCard hover.
+- **Card hover, lifted** (`box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25)` — `shadow-2xl`): EventCard hover. The signature "lift" of the site.
+
+### Named Rules
+
+**The Lift-on-Hover Rule.** Elevation is interactive, not decorative. Cards rest flat-ish, then lift. Static elevation on a non-interactive element (e.g. a panel that nothing happens to) is forbidden — it reads as nervous design.
+
+**The No-Glassmorphism Rule.** No `backdrop-filter: blur`, no translucent layered panes. Sponsors and faculty read the site; glass cards feel like a startup pitch deck.
+
+## 5. Components
+
+### Buttons
+- **Shape:** Slightly rounded rectangle (`rounded-md` / 8px). Pill buttons are reserved for category chips.
+- **Primary:** Brand Navy background (`#1B397E`), white text, `12px 24px` padding. Title typography (Inter 600, 24px).
+- **Hover / Focus:** Background shifts to Accent Blue Deep (`#1D4ED8`); focus emits a 2px Accent Blue ring with 2px white offset.
+- **Ghost:** Transparent background, Brand Navy text, same padding. Hover: text shifts to Accent Blue Deep, underline appears.
+
+### Chips (event category)
+- **Style:** Pill (`rounded-full`), `4px 12px` padding, label typography. One of the eight categorical pairs from the Colors section — never any other color.
+- **Position:** Absolute, top-left of an event card image, with a subtle `shadow-sm`.
+
+### Cards — Event
+- **Corner Style:** `rounded-xl` (12px).
+- **Background:** Surface White.
+- **Shadow Strategy:** `shadow-lg` at rest → `shadow-2xl` on hover (see Elevation).
+- **Border:** 1px Hairline (`#E5E7EB`).
+- **Internal Padding:** `0` on the wrapper (image is full-bleed), `1rem` on the text region.
+- **Hover Behavior:** Scale 1.02, image inside zooms scale 1.10, gradient overlay from black/40 fades in over the image bottom.
+- **Signature:** Image-led card. The event poster is the protagonist; copy supports.
+
+### Cards — Member
+- **Corner Style:** `rounded-xl` (12px).
+- **Background:** Surface White.
+- **Shadow Strategy:** `shadow-lg` at rest → `shadow-xl` on hover.
+- **Internal Padding:** `1.25rem` mobile, `1.5rem` desktop.
+- **Hover Behavior:** Scale **1.25** — deliberately exuberant; the team page is the warm-hearted chapter of the yearbook.
+- **Focus Ring:** 2px Accent Blue with 2px offset on keyboard focus, when the card is an external LinkedIn link.
+- **Photo:** Circular (`rounded-full`), `96–112px` square, 2px Hairline border.
+
+### Inputs / Fields
+- **Style:** White background, 1px Hairline border, `rounded-md` (8px), `12px 16px` padding, body typography.
+- **Focus:** Border shifts to Accent Blue (`#2563EB`), 3px Accent Blue ring at 25% opacity. No "glow."
+- **Error:** 1px `#DC2626` (red-600) border, helper text in `#B91C1C` (red-700).
+- **Disabled:** Background `#F9FAFB` (gray-50), text Ink Soft.
+
+### Navigation
+- **Style:** Inline horizontal nav on desktop, hamburger sheet on mobile. Inter 600 at body size.
+- **Default:** Ink Strong text.
+- **Hover:** Text shifts to Brand Navy.
+- **Active (desktop):** Brand Navy text; no underline, no background.
+- **Active (mobile):** Brand Navy text on Surface Tint Blue (`#EFF6FF`) `rounded-md` pill.
+- **Mobile toggle:** Min `48×48px` tap target.
+
+### Hero Section (signature)
+- **Layout:** Full-bleed photographic background (`object-cover`), `75vh` tall capped at `600px`, Scrim (`rgba(0,0,0,0.40)`) over the image so display type stays legible.
+- **Type:** Left-aligned Display + Subdisplay in white, tracked.
+- **Motion:** GSAP fade-rise from `y: 20, opacity: 0` to `y: 0, opacity: 1`, `power2.out`, 0.8s, subdisplay staggered `-0.6s`. Respects `prefers-reduced-motion` (currently relies on user OS — flagged as a Don't to enforce explicitly).
+
+### Sponsor Carousel (signature)
+- **Layout:** Slick carousel, 3 slides desktop / 2 tablet / 2 mobile, autoplay 4.5s, pause on hover. Arrows in Accent Blue.
+- **Cell:** Each slide centers a sponsor logo with generous padding, white background, no card chrome — the logo *is* the card.
+
+## 6. Do's and Don'ts
+
+### Do:
+- **Do** lead with real CEUS photography. Events, members, lab moments. Photography is the warmth budget.
+- **Do** reserve Brand Navy (`#1B397E`) for identity moments (footer, primary button, active nav). Use Accent Blue (`#2563EB`) for interactive accents only.
+- **Do** keep cards flat-ish at rest and let hover do the lifting (`shadow-lg` → `shadow-xl/2xl`, gentle scale).
+- **Do** keep Inter as the only typeface. Pull personality from weight (400/600/700) and the tracked hero.
+- **Do** confine the eight categorical colors to event chips only.
+- **Do** test display headings at every breakpoint. The clamp ceilings here are deliberate; if copy overflows, rewrite the copy or lower the clamp max.
+- **Do** make every motion respect `prefers-reduced-motion`. The GSAP hero, slick autoplay, and `1.25x` member-card scale all need the reduced-motion alternative wired explicitly.
+
+### Don't:
+- **Don't** put the page into navy-and-gold institutional dress. The "generic university department" anti-reference (from PRODUCT.md) is the single most likely failure mode for a UNSW society site.
+- **Don't** reach for the SaaS landing-page hero-metric template ("10,000+ members served"). The community is the proof, not the metric.
+- **Don't** use clip-art, stock illustrations, or generic "students at laptops" stock photography — the hobby-club register kills sponsor trust.
+- **Don't** introduce a second typeface for "warmth." Inter at the right weight is the warmth.
+- **Don't** promote any categorical event color to a page-level background, gradient stop, or section accent. They live in chips, full stop.
+- **Don't** use glassmorphism, gradient orbs, or animated mesh backgrounds. Corporate-finance / fintech aesthetic is on the no-list.
+- **Don't** use `border-left: 4px solid <color>` as a callout accent. Use a full border or a tinted background.
+- **Don't** use gradient text (`background-clip: text`). Emphasis via weight or size, not color tricks.
+- **Don't** use the eyebrow / 01·02·03 numbered-section template as default scaffolding. The site has six pages — number them only if the order carries real information.
+- **Don't** let the `admin` UI bleed into the public site's visual language. Admin is a small product surface inside an otherwise brand site; the public visitor should never encounter or infer it.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,60 @@
+# Product
+
+## Register
+
+brand
+
+## Users
+
+Three audiences sharing one site, with a strong primary:
+
+- **Primary — UNSW Chemical Engineering students** (prospective and current). They land here when deciding whether to join CEUS, looking up an upcoming event, checking who's on the exec, or hunting for industry connections. Mobile-heavy, time-pressed, browsing between classes.
+- **Secondary — corporate sponsors and prospective partners.** Engineering firms evaluating CEUS as a recruitment / brand channel. Desktop-heavy, looking for credibility cues (active events, real student body, past partners).
+- **Internal — CEUS executive team** using `/admin` to keep events, sponsors, and team profiles current. Not the design audience; the admin surface is the small product register inside this otherwise brand site.
+
+## Product Purpose
+
+The CEUS website is the society's public face. It exists to:
+
+1. **Recruit and retain** chemical engineering students into the society's community and event calendar.
+2. **Showcase the society's activity** (events, exec team, publications) so members and prospective members trust it's alive and worth their time.
+3. **Surface and credit sponsors** so industry partnerships feel valuable to both sides and renew year over year.
+
+Success looks like: students arriving via search or word of mouth find the next event in under 10 seconds; sponsors see their logo treated with care; the exec team can update content without touching code.
+
+## Brand Personality
+
+Three words: **student-led, credible, warm.**
+
+- **Student-led** — written by students for students. The voice should sound like a smart peer, not a university comms office.
+- **Credible** — it's still an engineering society at a research university. The visuals shouldn't feel like a club hobby page; sponsors need to take it seriously.
+- **Warm** — community, not corporate. Photography of real people doing real things beats stock; warmth in color and copy makes it inviting rather than intimidating to first-years.
+
+Emotional goals: *belonging* (you're one of us), *momentum* (something is always happening), *trust* (we're organized and worth your time).
+
+## Anti-references
+
+- **Generic university department pages** — dense walls of text, stock banner photo, navy-gold institutional palette, no sense of who's behind it.
+- **Generic SaaS marketing template** — hero-metric template, identical icon-card grids, "supercharge your engineering experience" copy. The site is a community, not a product launch.
+- **Hobby-club site** — clip art, Comic Sans energy, low-effort screenshots. Sponsors won't trust it.
+- **Overly serious / corporate finance aesthetic** — black + gold, glass cards, gradient orbs. This isn't a startup pitch deck.
+
+## Design Principles
+
+1. **Real over stock.** Photography of actual CEUS events, members, and labs always beats library imagery. The site's credibility comes from showing the society is real and active.
+2. **The next event is the lede.** Whatever a student lands for, they should see what's happening soon, without scrolling, without filters.
+3. **Sponsors get dignity, not vanity.** Logos at readable size, in context, with care. Sponsors fund the society; the site should make them feel that.
+4. **Light scaffolding.** This is a small site for a small audience. Resist over-engineering — no needless dashboards, no "build a design system" detour. Edit content, ship the page.
+5. **Admin invisible to the public.** The exec dashboard is a tool, not a feature. Public visitors should never encounter, infer, or be slowed down by its existence.
+
+## Accessibility & Inclusion
+
+- **Target WCAG 2.1 AA.** This is a UNSW student society site; the university expects it, and members include students with disabilities.
+- **Body text ≥4.5:1 contrast** on every surface. The blue accent (currently `text-blue-600`) is fine on white but needs verification on tinted or photographic backgrounds.
+- **Reduced motion.** GSAP hero animation, slick carousel autoplay, and any future scroll-driven motion must respect `prefers-reduced-motion`.
+- **Keyboard navigation.** Sponsor carousel, event filter buttons, modal close — all reachable and operable without a mouse.
+- **Alt text on every photo.** Events, team members, sponsor logos. Auto-fallbacks are not enough.
+
+---
+
+*Note: this PRODUCT.md was inferred from the codebase, README, and SEO metadata. Sections most worth confirming with the team: **Brand Personality** (the three words), **Anti-references** (any specific sites the exec wants to avoid resembling), and **Design Principles 1 & 3** (whether real photography and sponsor presentation are in fact the load-bearing visual commitments). Run `/impeccable init` to refine these via interview.*


### PR DESCRIPTION
## Summary

Rewrite of the home page (`CEUS/src/app/HomeClient.tsx`) to match the brand register documented in the new `PRODUCT.md` / `DESIGN.md`. Critique score moved from **24/40 → 33/40**.

- Hero now leads with a concrete promise (*"Events, industry connections, and the people you'll meet along the way."*) and a single Brand Navy CTA anchoring to `#happening`, instead of restating the brand name with no call to action.
- Sections reordered: Hero → Happening Soon → Sponsors → Video → About CEUS. The events carousel is now directly under the hero (per the "next event is the lede" project principle); About CEUS is at the foot of the page.
- About copy rewritten out of generic university-comms voice ("vibrant, student-run organisation, fosters connection...") into one paragraph in student-led voice with specific nouns.
- CTA palette aligned: every CTA on the page is now either Brand Navy primary (`#1B397E`) or Brand Navy ghost. Both `bg-blue-600` and the rogue `bg-emerald-600` are gone.
- Heading hierarchy: Happening Soon dominates (`text-4xl md:text-5xl lg:text-6xl`), supporting sections demoted to `text-3xl md:text-4xl`.
- Empty states gained brand-voice copy + Brand Navy CTAs (sponsor empty state now reaches *out* to prospective sponsors).
- GSAP hero animation wrapped in `prefers-reduced-motion` guard via `useIsomorphicLayoutEffect`. Slick autoplay also detects the preference and disables autoplay for reduced-motion users.

## Project-level scaffolding included

This PR also lands the foundational design-context files (everything else builds on these):

- `PRODUCT.md` — register (brand), users, brand personality, anti-references, design principles, a11y target.
- `DESIGN.md` — Stitch-format design system spec.
- `.impeccable/design.json` — sidecar with tonal ramps, motion tokens, and self-contained component HTML/CSS.
- `CEUS/src/index.css` — `scroll-behavior: smooth` (reduced-motion aware) and the shared `animate-fade-in-up` keyframes.
- `CEUS/src/lib/links.ts` — hoists `CALENDAR_SUBSCRIBE_URL` so the next URL change is a one-line edit.
- Two critique snapshots in `CEUS/.impeccable/critique/` (pre- and post-polish home page scores).

## Test plan

- [ ] `cd CEUS && npm run dev` → load `/`, verify hero CTA scrolls smoothly to `#happening`
- [ ] Try the page with `prefers-reduced-motion: reduce` set (browser DevTools → Rendering panel). Confirm: GSAP hero is static, slick autoplay is disabled, smooth-scroll falls back to instant
- [ ] At mobile (≤640px), verify the hero CTAs stack and reach with the thumb; verify About CEUS no longer pushes events below the fold
- [ ] If the calendar URL changes, update only `CEUS/src/lib/links.ts`

## Verification

- `tsc --noEmit`: clean (exit 0)
- `eslint`: clean (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)